### PR TITLE
Document updates: docker-compose.yml / How_to_generate_an_bcrypt_hash.md

### DIFF
--- a/How_to_generate_an_bcrypt_hash.md
+++ b/How_to_generate_an_bcrypt_hash.md
@@ -12,12 +12,12 @@
 To generate a bcrypt password hash using docker, run the following command :
 
 ```sh
-docker run -it ghcr.io/wg-easy/wg-easy wgpw YOUR_PASSWORD
+docker run --rm -it ghcr.io/wg-easy/wg-easy wgpw 'YOUR_PASSWORD'
 PASSWORD_HASH='$2b$12$coPqCsPtcFO.Ab99xylBNOW4.Iu7OOA2/ZIboHN6/oyxca3MWo7fW' // literally YOUR_PASSWORD
 ```
 If a password is not provided, the tool will prompt you for one :
 ```sh
-docker run -it ghcr.io/wg-easy/wg-easy wgpw
+docker run --rm -it ghcr.io/wg-easy/wg-easy wgpw
 Enter your password:      // hidden prompt, type in your password
 PASSWORD_HASH='$2b$12$coPqCsPtcFO.Ab99xylBNOW4.Iu7OOA2/ZIboHN6/oyxca3MWo7fW'
 ```
@@ -39,4 +39,4 @@ $2b$12$coPqCsPtcF
 - PASSWORD_HASH=$$2y$$10$$hBCoykrB95WSzuV4fafBzOHWKu9sbyVa34GJr8VV5R/pIelfEMYyG
 ```
 
-This hash is for the password 'foobar123', obtained using the command `docker run ghcr.io/wg-easy/wg-easy wgpw foobar123` and then inserted an additional `$` before each existing `$` symbol.
+This hash is for the password 'foobar123', obtained using the command `docker run ghcr.io/wg-easy/wg-easy wgpw 'foobar123'` and then inserted an additional `$` before each existing `$` symbol.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - WG_HOST=raspberrypi.local
 
       # Optional:
-      # - PASSWORD_HASH=$$2y$$10$$hBCoykrB95WSzuV4fafBzOHWKu9sbyVa34GJr8VV5R/pIelfEMYyG (needs double $$, hash of 'foobar123'; see "How_to_generate_an_bcrypt_hash.md" for generate the hash)
+      # - PASSWORD_HASH=$$2y$$10$$hBCoykrB95WSzuV4fafBzOHWKu9sbyVa34GJr8VV5R/pIelfEMYyG # (needs double $$, hash of 'foobar123'; see "How_to_generate_an_bcrypt_hash.md" for generate the hash)
       # - PORT=51821
       # - WG_PORT=51820
       # - WG_CONFIG_PORT=92820


### PR DESCRIPTION
## Description

Update for How_to_generate_an_bcrypt_hash.md:

- Inclusion of single quotes for password with docker run command
- Addition of "--rm" parameter to docker run command, to cleanup the (new) wg-easy container which gets created automatically during with the password hash generation command

Update for docker-compose.yml:

- Addition of missing # before the comment on PASSWORD_HASH line
